### PR TITLE
Fix remove player from instance table

### DIFF
--- a/pmc-instance/instance.lua
+++ b/pmc-instance/instance.lua
@@ -39,7 +39,7 @@ instanceMeta.__index = {
 						return function(self, source)
 							assert(type(source) == 'number', 'invalid Lua type in argument #1, got '..type(source))
 							if _INSTANCE_INTERNAL.SourceExists(source) then
-								TriggerEvent('__instance_internal:instance:player:remove', source)
+								TriggerEvent('__instance_internal:instance:player:remove', self.instanceIndex, source)
 							end
 						end
 					elseif index == 'getPlayers' then

--- a/pmc-instance/server/misc.lua
+++ b/pmc-instance/server/misc.lua
@@ -42,28 +42,35 @@ setmetatable(U, {
 						SPRB(_s, _in)
 						self:DebugMessage(_s, _in)
 					else
-						self:EnsureChangePlayer(_in, _s)
+						self:EnsureChangePlayer(_in, _s, true)
 					end
 				end
 			end
 		end,
-		EnsureRemovePlayer = function(self, _s)
+		EnsureRemovePlayer = function(self, _in, _s)
 			if self:Ensure(_s, 'number') then
-				self:EnsureChangePlayer(0, _s)
+				self:EnsureChangePlayer(_in, _s)
 			end
 		end,
-		EnsureChangePlayer = function(self, _in, _s)
+		EnsureChangePlayer = function(self, _in, _s, _shouldAdd)
 			if self:Ensure(_in, 'number') and self:Ensure(_s, 'number') then
 				local _c_in = GPRB(_s)
+
 				if self:EnsureInstance(_in) and self:EnsureInstance(_c_in) then
 					if _c_in ~= 0 then
-						for _i, _v in ipairs(Instances[_in].players) do
-							if _v == _s then
-								Instances[_in].players[_i] = nil
-								break
+						if _shouldAdd then
+							Instances[_in].players[#Instances[_in].players + 1] =_s
+						else
+							for _i, _v in ipairs(Instances[_in].players) do
+								if _v == _s then
+									Instances[_in].players[_i] = nil
+									break
+								end
 							end
 						end
-						table.insert(Instances[_in].players, _s)
+
+						_in = _shouldAdd and _in or 0
+						
 						SPRB(_s, _in)
 						self:DebugMessage(_s, _in)
 					end

--- a/pmc-instance/server/misc.lua
+++ b/pmc-instance/server/misc.lua
@@ -47,9 +47,9 @@ setmetatable(U, {
 				end
 			end
 		end,
-		EnsureRemovePlayer = function(self, _in, _s, _shouldAdd)
+		EnsureRemovePlayer = function(self, _in, _s)
 			if self:Ensure(_s, 'number') then
-				self:EnsureChangePlayer(_in, _s, _shouldAdd)
+				self:EnsureChangePlayer(_in, _s, false)
 			end
 		end,
 		EnsureChangePlayer = function(self, _in, _s, _shouldAdd)

--- a/pmc-instance/server/misc.lua
+++ b/pmc-instance/server/misc.lua
@@ -47,9 +47,9 @@ setmetatable(U, {
 				end
 			end
 		end,
-		EnsureRemovePlayer = function(self, _in, _s)
+		EnsureRemovePlayer = function(self, _in, _s, _shouldAdd)
 			if self:Ensure(_s, 'number') then
-				self:EnsureChangePlayer(_in, _s)
+				self:EnsureChangePlayer(_in, _s, _shouldAdd)
 			end
 		end,
 		EnsureChangePlayer = function(self, _in, _s, _shouldAdd)


### PR DESCRIPTION
Hi.

I took the liberty of removing the player from the table associated with the instance to avoid doing so in the scripts that depend on it. 
No break changes involved.